### PR TITLE
Fix standard wordpress redirect functionality

### DIFF
--- a/includes/login.php
+++ b/includes/login.php
@@ -191,6 +191,10 @@ function login_form() {
 			<?php endif; ?>
 			<input type="text" name="log" id="user_login" class="input" value="" size="20" autocapitalize="off" required />
 		</p>
+		<?php if(isset($_GET['redirect_to'])) : ?>
+			<input type="hidden" name="redirect_to" value="<?php $_GET['redirect_to']; ?>">
+		<?php endif; ?>
+
 		<?php
 
 		/**


### PR DESCRIPTION
Currently the magic login form breaks standard wordpress redirect functionality, since with the normal login form it's possible to redirect back to the page you came from, by adding a `redirect_to` value in the url. By adding a hidden value in the form, this is fixed.