### PR TITLE
Consistently unslash superglobals before use

### DIFF
--- a/includes/admin/dashboard.php
+++ b/includes/admin/dashboard.php
@@ -148,7 +148,7 @@ function save_settings() {
 
 		// convert TTL in minute
 		if ( isset( $_POST['token_ttl'] ) && $_POST['token_ttl'] > 0 && isset( $_POST['token_interval'] ) ) {
-			switch ( $_POST['token_interval'] ) {
+			switch ( sanitize_text_field( wp_unslash( $_POST['token_interval'] ) ) ) {
 				case 'DAY':
 					$settings['token_ttl'] = absint( $_POST['token_ttl'] ) * 1440;
 					break;

--- a/includes/classes/CodeLogin.php
+++ b/includes/classes/CodeLogin.php
@@ -209,7 +209,7 @@ class CodeLogin {
 				<?php endif; ?>
 
 				<?php if ( isset( $_POST['redirect_to'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
-					<input type="hidden" name="redirect_to" value="<?php echo esc_url( $_POST['redirect_to'] ); // phpcs:ignore ?>">
+					<input type="hidden" name="redirect_to" value="<?php echo esc_url( wp_unslash( $_POST['redirect_to'] ) ); // phpcs:ignore ?>">
 				<?php endif; ?>
 				<input type="hidden" name="log" value="<?php echo esc_attr( $log ); ?>" />
 				<input type="hidden" name="testcookie" value="1" />

--- a/includes/classes/LoginManager.php
+++ b/includes/classes/LoginManager.php
@@ -630,7 +630,7 @@ class LoginManager {
 		$login_url = get_wp_login_url();
 
 		if ( isset( $_GET['redirect_to'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$login_url = esc_url_raw( add_query_arg( 'redirect_to', urlencode( $_GET['redirect_to'] ), $login_url ) ); // phpcs:ignore
+			$login_url = esc_url_raw( add_query_arg( 'redirect_to', urlencode( wp_unslash( $_GET['redirect_to'] ) ), $login_url ) ); // phpcs:ignore
 		}
 
 		?>
@@ -720,7 +720,7 @@ class LoginManager {
 		do_action( 'magic_login_handle_login_request' );
 		// Use a generic error message to ensure user ids can't be sniffed
 		$user_id = (int) $_GET['user_id']; //phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$token   = $_GET['token']; //phpcs:ignore
+		$token   = wp_unslash( $_GET['token'] ); //phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		self::authenticate_user_token( $user_id, $token );
 	}
 
@@ -835,7 +835,7 @@ class LoginManager {
 
 		// Determine redirect URL.
 		$redirect_to           = get_user_default_redirect( $user );
-		$requested_redirect_to = isset( $_REQUEST['redirect_to'] ) && is_string( $_REQUEST['redirect_to'] ) ? $_REQUEST['redirect_to'] : ''; // phpcs:ignore
+		$requested_redirect_to = isset( $_REQUEST['redirect_to'] ) && is_string( $_REQUEST['redirect_to'] ) ? wp_unslash( $_REQUEST['redirect_to'] ) : ''; // phpcs:ignore
 
 		$redirect_to    = apply_filters( 'login_redirect', $redirect_to, $requested_redirect_to, $user );
 		$login_redirect = apply_filters( 'magic_login_redirect', $redirect_to, $user );
@@ -976,7 +976,7 @@ class LoginManager {
 			<p class="submit">
 				<input type="submit" name="wp-submit" id="wp-submit" style="float: none;width: 100%;" class="magic-login-submit button button-primary button-hero" value="<?php esc_attr_e( 'Send me the link', 'magic-login' ); ?>" />
 				<?php if ( isset( $_GET['redirect_to'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
-					<input type="hidden" name="redirect_to" value="<?php echo esc_url( $_GET['redirect_to'] ); // phpcs:ignore ?>">
+					<input type="hidden" name="redirect_to" value="<?php echo esc_url( wp_unslash( $_GET['redirect_to'] ) ); // phpcs:ignore ?>">
 				<?php endif; ?>
 				<input type="hidden" name="testcookie" value="1" />
 			</p>

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -167,7 +167,7 @@ function shortcode_login_form( $shortcode_atts ) {
  */
 function maybe_shortcode_redirect( $redirect_url, $user ) {
 	if ( isset( $_REQUEST['redirect_to'] ) && $_REQUEST['redirect_to'] ) { // phpcs:ignore
-		$redirect_url = esc_url_raw( $_REQUEST['redirect_to'] ); // phpcs:ignore
+		$redirect_url = esc_url_raw( wp_unslash( $_REQUEST['redirect_to'] ) ); // phpcs:ignore
 	}
 
 	return $redirect_url;


### PR DESCRIPTION
## Summary
- Adds `wp_unslash()` before sanitizing/using `$_GET`/`$_POST`/`$_REQUEST` values in 7 spots (redirect_to handling in LoginManager, CodeLogin, shortcode; the magic-link token; the settings token_interval switch).
- Output was already escaped downstream in nearly all cases, so this is defense-in-depth hardening for consistency with the rest of the codebase, not a fix for a known-exploitable bug.
- The magic-link token itself is left unsanitized after `wp_unslash()` — it's an opaque value that's hashed and compared exactly, so `sanitize_text_field()` adds no security and risked mangling tokens customized via the `magic_login_create_user_token` filter.

## Why
Found during a security audit pass: these call sites were the only ones in the codebase reading superglobals without `wp_unslash()` first.

## Test Plan
- [x] `php -l` on all changed files — no syntax errors
- [x] `vendor/bin/phpcs --standard=phpcs.xml` on changed files — 0 errors/warnings
- [x] `vendor/bin/phpunit` — 8/8 passing
- [x] Activated plugin on a local WP 7.0.4 site — no fatals/warnings in the error log
- [x] `wp-login.php?redirect_to=...` renders the hidden field correctly (unslashed + escaped)
- [x] Settings-save token_interval switch verified behavior-preserving for normal values and correctly strips magic-quote-style slashing on malformed input