### PR TITLE
Fix Plugin Check errors and PHP 8.1/8.2 compatibility deprecations

### DIFF
--- a/includes/admin/dashboard.php
+++ b/includes/admin/dashboard.php
@@ -161,7 +161,7 @@ function save_settings() {
 			}
 		}
 
-		$token_interval    = sanitize_text_field( filter_input( INPUT_POST, 'token_interval' ) );
+		$token_interval    = sanitize_text_field( filter_input( INPUT_POST, 'token_interval' ) ?? '' );
 		$allowed_intervals = get_allowed_intervals();
 
 		if ( isset( $allowed_intervals[ $token_interval ] ) ) {

--- a/includes/admin/partials/tabs/login.php
+++ b/includes/admin/partials/tabs/login.php
@@ -495,8 +495,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 								'max' => 600,
 							),
 						);
+						$brute_force_inputs = array();
 						foreach ( $brute_force_fields as $field => $args ) {
-							${$field . '_input'} = sprintf(
+							$brute_force_inputs[ $field ] = sprintf(
 								'<input
 															id="%1$s"
 															name="%1$s"
@@ -515,9 +516,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 						/* translators: 1: Ban duration input 2: Trial count input 3: Interval input */
 						printf(
 							__( 'Block the IP address for %1$s minutes when it fails to login %2$s times in %3$s minutes.', 'magic-login' ), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-							$brute_force_bantime_input, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-							$brute_force_login_attempt_input, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-							$brute_force_login_time_input // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							$brute_force_inputs['brute_force_bantime'], // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							$brute_force_inputs['brute_force_login_attempt'], // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							$brute_force_inputs['brute_force_login_time'] // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						?>
 					</div>

--- a/includes/classes/LoginManager.php
+++ b/includes/classes/LoginManager.php
@@ -395,15 +395,18 @@ class LoginManager {
 		$excluded_subjects = apply_filters(
 			'magic_login_auto_login_excluded_subjects',
 			[
-				__( '[%s] New Admin Email Address' ),
-				__( '[%s] Network Admin Email Change Request' ),
-				__( '[%s] Admin Email Changed' ),
-				__( '[%s] Notice of Network Admin Email Change' ),
-				__( '[%s] Login Details' ),
-				__( '[%s] Password Reset' ),
-				__( '[%s] Password Changed' ),
-				__( '[%s] Email Change Request' ),
-				__( 'Your login confirmation code' ),
+				// These intentionally use WP core's own "default" text domain (not 'magic-login')
+				// because they must match the untranslated/core-translated subjects WP core itself
+				// sends, not a magic-login-specific translation.
+				__( '[%s] New Admin Email Address', 'default' ),
+				__( '[%s] Network Admin Email Change Request', 'default' ),
+				__( '[%s] Admin Email Changed', 'default' ),
+				__( '[%s] Notice of Network Admin Email Change', 'default' ),
+				__( '[%s] Login Details', 'default' ),
+				__( '[%s] Password Reset', 'default' ),
+				__( '[%s] Password Changed', 'default' ),
+				__( '[%s] Email Change Request', 'default' ),
+				__( 'Your login confirmation code', 'default' ),
 			]
 		);
 
@@ -1175,7 +1178,9 @@ class LoginManager {
 			if ( false !== stripos( $header, 'text/html' ) ) {
 				// convert line breaks to br when content type is html but
 				// input doesn't contain HTML tags (adding <br/> can ruin the templating)
-				if ( strip_tags( $login_email, '<a>' ) === $login_email ) {
+				// wp_strip_all_tags() has no allowed-tags argument, and the default email
+				// template legitimately contains an <a> link, so the native function is required here.
+				if ( strip_tags( $login_email, '<a>' ) === $login_email ) { // phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags
 					$login_email = nl2br( $login_email );
 				}
 				break;


### PR DESCRIPTION
## Summary
- Fixes a real Plugin Check ERROR (`WordPress.WP.I18n.MissingArgDomain`) on 9 lines in LoginManager.php by passing `'default'` explicitly instead of omitting the domain — preserves the intentional behavior of matching WP core's own email subjects.
- Replaces a `${$field . '_input'}` dynamic variable-variable (deprecated in PHP 8.2) with a plain array in the brute-force settings UI.
- Guards `filter_input()` against returning `null` into `sanitize_text_field()` (PHP 8.1+ deprecation) when saving settings.
- Documents (does not replace) a `strip_tags()` call: `wp_strip_all_tags()` has no allowed-tags argument, and swapping it would silently change which login emails get `nl2br()`'d, since the default template contains a real `<a>` link.

## Test Plan
- [x] `php -l` — no syntax errors
- [x] `vendor/bin/phpcs --standard=phpcs.xml` — 0 errors/warnings
- [x] `vendor/bin/phpunit` — 8/8 passing
- [x] `wp plugin check magic-login` (official Plugin Check plugin, WP-CLI): `MissingArgDomain` errors 9 → 0
- [x] Rendered the brute-force-protection settings block via direct template include — all 3 dynamic inputs present, byte-identical structure, no fatals