### PR TITLE
Verify PHPCS/WPCS compliance; fix one incomplete docblock

### DIFF
--- a/includes/classes/CodeLogin.php
+++ b/includes/classes/CodeLogin.php
@@ -22,7 +22,7 @@ class CodeLogin {
 	/**
 	 * Return an instance of the current class
 	 *
-	 * @since
+	 * @since 2.4
 	 */
 	public static function setup() {
 		static $instance = false;


### PR DESCRIPTION
## Summary
- Full-repo `phpcs` scan against the project's own ruleset (10up-Default / phpcs.xml, what `composer run lint` actually runs): **0 errors, 0 warnings** across all 23 files — no fixes needed there.
- Scanned every function/method for a missing docblock entirely: **none found**.
- Fixed the one real gap: an empty `@since` tag in `CodeLogin::setup()` (every other tag in the file says `2.4`, filled in to match).
- Explicitly did **not** re-apply the generic vanilla `WordPress` ruleset — it flags ~240 things (short array syntax, comment punctuation, PSR-4 filenames, the nonce sniff), every one of which `phpcs.xml` already excludes on purpose with a documented reason. "Fixing" those would fight the project's own conventions, not improve anything.

## Test Plan
- [x] `php -l` — no syntax errors
- [x] `vendor/bin/phpcs --standard=phpcs.xml .` (full repo) — 0 errors/warnings, before and after
- [x] `vendor/bin/phpunit` — 8/8 passing